### PR TITLE
fix: remove phase number zero-padding in stclaude

### DIFF
--- a/.planning/quick/001-fix-phase-number-zero-padding/001-PLAN.md
+++ b/.planning/quick/001-fix-phase-number-zero-padding/001-PLAN.md
@@ -1,0 +1,72 @@
+---
+phase: quick
+plan: 001
+type: execute
+autonomous: true
+files_modified:
+  - /Users/gustav/.claude/bin/stclaude.mjs
+  - /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md
+  - /Users/gustav/.claude/get-shit-done/workflows/add-phase.md
+  - /Users/gustav/.claude/get-shit-done/workflows/plan-phase.md
+---
+
+<objective>
+Fix phase number zero-padding inconsistency. Phase numbers passed to stclaude should be plain integers (1, 2, 12) not zero-padded strings ("01", "02", "12"). The SpacetimeDB column is typed — padding causes lookup mismatches.
+
+Root cause: `padPhaseNumber()` in stclaude.mjs zero-pads numbers before storage, and `findPhaseByNumber()` does exact string matching.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Fix stclaude.mjs — remove padding, normalize lookups</name>
+  <files>/Users/gustav/.claude/bin/stclaude.mjs</files>
+  <action>
+1. Find `padPhaseNumber()` function and change it to return plain number strings (no padding):
+   ```javascript
+   function padPhaseNumber(n) {
+     return n.toString();  // No padding — plain number
+   }
+   ```
+   Or inline the calls and remove the function entirely.
+
+2. Find `findPhaseByNumber()` and make it normalize both the input and stored values by stripping leading zeros before comparison:
+   ```javascript
+   // Normalize: strip leading zeros for comparison
+   const normalizedInput = number.replace(/^0+/, '') || '0';
+   // Compare against stored value also normalized
+   row.number.replace(/^0+/, '') === normalizedInput
+   ```
+   This ensures both "01" and "1" match existing data, providing backward compatibility with already-stored zero-padded values.
+
+3. Check if there are any other places in stclaude.mjs that zero-pad phase numbers (search for `padStart`, `padPhaseNumber`, `printf "%02d"`). Fix all of them.
+  </action>
+  <verify>
+    <automated>grep -n "padStart" /Users/gustav/.claude/bin/stclaude.mjs | grep -v "node_modules"</automated>
+  </verify>
+  <done>stclaude.mjs no longer zero-pads phase numbers for new phases. findPhaseByNumber normalizes both sides of comparison. Existing zero-padded data still works.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update phase-argument-parsing.md and workflow references</name>
+  <files>
+    /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md
+    /Users/gustav/.claude/get-shit-done/workflows/add-phase.md
+    /Users/gustav/.claude/get-shit-done/workflows/plan-phase.md
+  </files>
+  <action>
+1. In phase-argument-parsing.md: Remove the "Manual Normalization (Legacy)" section that instructs `printf "%02d"` zero-padding. Replace with a note that stclaude handles normalization internally — callers should pass phase numbers as-is (plain integers).
+
+2. In add-phase.md: The `printf "%02d"` for directory naming can stay (filesystem directories are cosmetic). But ensure the phase number passed to `stclaude add-phase` is NOT zero-padded.
+
+3. In plan-phase.md: Check if `$PADDED_PHASE` is used for stclaude calls — if so, use plain `$PHASE` instead. Keep `$PADDED_PHASE` only for filesystem directory naming.
+
+4. Search across all recently-patched workflows for any remaining `printf "%02d"` applied to phase numbers before stclaude calls. The filesystem directory naming can keep padding, but stclaude arguments must be plain numbers.
+  </action>
+  <verify>
+    <automated>grep -rn 'printf.*%02d.*PHASE' /Users/gustav/.claude/get-shit-done/workflows/ /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md</automated>
+  </verify>
+  <done>phase-argument-parsing.md no longer instructs zero-padding for stclaude calls. Workflow files pass plain phase numbers to stclaude. Filesystem directory naming may still use padding (cosmetic only).</done>
+</task>
+
+</tasks>

--- a/.planning/quick/001-fix-phase-number-zero-padding/001-SUMMARY.md
+++ b/.planning/quick/001-fix-phase-number-zero-padding/001-SUMMARY.md
@@ -1,0 +1,83 @@
+---
+quick: 001
+subsystem: stclaude-cli
+tags: [bug-fix, phase-numbers, zero-padding]
+key-files:
+  modified:
+    - /Users/gustav/.claude/bin/stclaude.mjs
+    - /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md
+decisions:
+  - Normalize both input and stored values in findPhaseByNumber for backward compat
+  - padPhaseNumber returns plain number string (no padding)
+  - Filesystem directory naming can still use zero-padding (cosmetic only)
+metrics:
+  completed: 2026-03-09
+---
+
+# Quick Task 001: Fix Phase Number Zero-Padding Summary
+
+Fixed phase number zero-padding inconsistency in stclaude.mjs so plain integers (1, 2, 12) work correctly for SpacetimeDB lookups, with backward compatibility for already-stored zero-padded values.
+
+## Completed Tasks
+
+| Task | Name | Files |
+|------|------|-------|
+| 1 | Fix stclaude.mjs — remove padding, normalize lookups | /Users/gustav/.claude/bin/stclaude.mjs |
+| 2 | Update phase-argument-parsing.md and workflow references | /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md |
+
+## Changes Made
+
+### Task 1: stclaude.mjs
+
+**`padPhaseNumber(n)` — removed zero-padding:**
+```javascript
+// Before:
+function padPhaseNumber(n) {
+  return n.toString().padStart(2, "0");
+}
+
+// After:
+function padPhaseNumber(n) {
+  return n.toString();  // No padding — plain number
+}
+```
+
+**`findPhaseByNumber()` — normalize both sides for backward compat:**
+```javascript
+// Before:
+function findPhaseByNumber(conn, projectId, number) {
+  for (const row of conn.db.phase.iter()) {
+    if (row.projectId === projectId && row.number === number) {
+
+// After:
+function findPhaseByNumber(conn, projectId, number) {
+  const normalizedInput = number.toString().replace(/^0+/, '') || '0';
+  for (const row of conn.db.phase.iter()) {
+    const normalizedRow = row.number.replace(/^0+/, '') || '0';
+    if (row.projectId === projectId && normalizedRow === normalizedInput) {
+```
+
+Both "01" and "1" now match a stored phase with either value — backward compatible with existing zero-padded data.
+
+No other `padStart` usages in stclaude.mjs are phase-related (they handle timestamp formatting, hex encoding, and todo ID display).
+
+### Task 2: phase-argument-parsing.md
+
+Replaced "Manual Normalization (Legacy)" section that instructed zero-padding with a clear note:
+- stclaude handles normalization internally
+- Pass plain integers to stclaude (no zero-padding)
+- Zero-padding acceptable only for filesystem directory naming (cosmetic)
+
+### Workflow files checked:
+- **add-phase.md**: stclaude call already passes plain number — no change needed. Filesystem `mkdir` uses `printf "%02d"` which is acceptable.
+- **plan-phase.md**: `${PADDED_PHASE}` only used for `VALIDATION.md` filename (filesystem, cosmetic) — no change needed.
+- **planning-config.md**: `PADDED_PHASE` for branch name (cosmetic) — no change needed.
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Self-Check: PASSED
+
+- /Users/gustav/.claude/bin/stclaude.mjs: padPhaseNumber no longer zero-pads, findPhaseByNumber normalizes both sides
+- /Users/gustav/.claude/get-shit-done/references/phase-argument-parsing.md: Legacy zero-padding section replaced with correct guidance


### PR DESCRIPTION
## Summary

- **`padPhaseNumber()`** in stclaude.mjs now returns plain `n.toString()` instead of zero-padded strings — new phases are stored as `"1"`, `"2"` not `"01"`, `"02"`
- **`findPhaseByNumber()`** normalizes both input and stored values (strips leading zeros) — backward compatible with existing zero-padded data in SpacetimeDB
- **`phase-argument-parsing.md`** updated to remove legacy zero-padding instructions for stclaude calls

## Test plan

- [ ] `stclaude add-phase --number 13 --name "Test" --goal "Test"` stores `"13"` not `"13"` (was already fine) and `"1"` not `"01"` for single-digit
- [ ] `stclaude get-phase 1` finds phases stored as either `"1"` or `"01"` (backward compat)
- [ ] `stclaude init execute-phase 12` works without zero-padding the argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)