### PR TITLE
fix: deduplicate plans and support plan updates

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -297,21 +297,24 @@ export function registerInitCommand(program: Command): void {
             (a, b) => parseFloat(a.number) - parseFloat(b.number),
           );
 
-          // Build phase-to-plans map
+          // Build phase-to-plans map, deduplicated by planNumber (keep latest id)
           const plansByPhase = new Map<
             bigint,
-            Array<{ planNumber: bigint; status: string }>
+            Map<bigint, { planNumber: bigint; status: string; id: bigint }>
           >();
           for (const row of conn.db.plan.iter()) {
-            const existing = plansByPhase.get(row.phaseId);
-            const entry = {
-              planNumber: row.planNumber,
-              status: row.status,
-            };
-            if (existing) {
-              existing.push(entry);
-            } else {
-              plansByPhase.set(row.phaseId, [entry]);
+            let phaseMap = plansByPhase.get(row.phaseId);
+            if (!phaseMap) {
+              phaseMap = new Map();
+              plansByPhase.set(row.phaseId, phaseMap);
+            }
+            const existing = phaseMap.get(row.planNumber);
+            if (!existing || row.id > existing.id) {
+              phaseMap.set(row.planNumber, {
+                planNumber: row.planNumber,
+                status: row.status,
+                id: row.id,
+              });
             }
           }
 
@@ -335,7 +338,7 @@ export function registerInitCommand(program: Command): void {
           // Build phases result with computed counts
           const phases: InitProgressData['phases'] = projectPhases.map(
             (phase) => {
-              const plans = plansByPhase.get(phase.id) || [];
+              const plans = [...(plansByPhase.get(phase.id)?.values() || [])];
               const reqs = reqsByPhaseNumber.get(phase.number) || [];
 
               return {
@@ -493,18 +496,22 @@ export function registerInitCommand(program: Command): void {
             }
           }
 
-          // Collect existing plans for this phase
-          const existingPlans: InitPlanPhaseData['existingPlans'] = [];
+          // Collect existing plans for this phase, deduplicated by planNumber (keep latest id)
+          const existingPlanMap = new Map<bigint, InitPlanPhaseData['existingPlans'][0]>();
           for (const row of conn.db.plan.iter()) {
             if (row.phaseId === phase.id) {
-              existingPlans.push({
-                id: row.id,
-                planNumber: row.planNumber,
-                objective: row.objective,
-                status: row.status,
-              });
+              const existing = existingPlanMap.get(row.planNumber);
+              if (!existing || row.id > existing.id) {
+                existingPlanMap.set(row.planNumber, {
+                  id: row.id,
+                  planNumber: row.planNumber,
+                  objective: row.objective,
+                  status: row.status,
+                });
+              }
             }
           }
+          const existingPlans = [...existingPlanMap.values()];
 
           return {
             phase: {
@@ -544,7 +551,8 @@ export function registerInitCommand(program: Command): void {
   initCmd
     .command('execute-phase <phase>')
     .description('Assemble execution workflow context for a phase')
-    .action(async (phaseNumber: string) => {
+    .option('--slim', 'Omit plan content from output', false)
+    .action(async (phaseNumber: string, cmdOpts: { slim: boolean }) => {
       const opts = program.opts<{ json: boolean }>();
 
       try {
@@ -554,8 +562,8 @@ export function registerInitCommand(program: Command): void {
           const project = findProjectByGitRemote(conn, gitRemoteUrl);
           const phase = findPhaseByNumber(conn, project.id, phaseNumber);
 
-          // Collect all plans for this phase, sorted by planNumber
-          const phasePlans: Array<{
+          // Collect all plans for this phase, deduplicated by planNumber (keep latest id)
+          const planByNumber = new Map<bigint, {
             id: bigint;
             planNumber: bigint;
             type: string;
@@ -566,23 +574,27 @@ export function registerInitCommand(program: Command): void {
             dependsOn: string;
             status: string;
             content: string;
-          }> = [];
+          }>();
           for (const row of conn.db.plan.iter()) {
             if (row.phaseId === phase.id) {
-              phasePlans.push({
-                id: row.id,
-                planNumber: row.planNumber,
-                type: row.type,
-                wave: row.wave,
-                objective: row.objective,
-                autonomous: row.autonomous,
-                requirements: row.requirements,
-                dependsOn: row.dependsOn,
-                status: row.status,
-                content: row.content,
-              });
+              const existing = planByNumber.get(row.planNumber);
+              if (!existing || row.id > existing.id) {
+                planByNumber.set(row.planNumber, {
+                  id: row.id,
+                  planNumber: row.planNumber,
+                  type: row.type,
+                  wave: row.wave,
+                  objective: row.objective,
+                  autonomous: row.autonomous,
+                  requirements: row.requirements,
+                  dependsOn: row.dependsOn,
+                  status: row.status,
+                  content: row.content,
+                });
+              }
             }
           }
+          const phasePlans = [...planByNumber.values()];
           phasePlans.sort((a, b) =>
             a.planNumber < b.planNumber ? -1 : a.planNumber > b.planNumber ? 1 : 0,
           );
@@ -660,7 +672,7 @@ export function registerInitCommand(program: Command): void {
               requirements: p.requirements,
               dependsOn: p.dependsOn,
               status: p.status,
-              content: p.content,
+              content: cmdOpts.slim ? '' : p.content,
               tasks,
               hasSummary: summaryByPlan.has(p.id),
               mustHaves: mustHavesByPlan.get(p.id) || [],

--- a/src/cli/commands/write-plan.ts
+++ b/src/cli/commands/write-plan.ts
@@ -146,36 +146,86 @@ export function registerWritePlanCommand(program: Command): void {
             options.phase,
           );
 
-          // Set up listener BEFORE calling reducer
-          const insertPromise = waitForInsert(
-            conn,
-            conn.db.plan,
-            (row) =>
+          const planNumberBigInt = BigInt(options.plan);
+
+          // Check if plan already exists for this (phase, planNumber)
+          let existingPlan = null;
+          for (const row of conn.db.plan.iter()) {
+            if (
               row.phaseId === phase.id &&
-              row.planNumber === BigInt(options.plan),
-          );
+              row.planNumber === planNumberBigInt
+            ) {
+              existingPlan = row;
+              break;
+            }
+          }
 
-          conn.reducers.insertPlan({
-            phaseId: phase.id,
-            planNumber: BigInt(options.plan),
-            type: options.type,
-            wave: BigInt(options.wave),
-            dependsOn: options.dependsOn,
-            objective: options.objective,
-            autonomous: options.autonomous,
-            requirements: options.requirements,
-            status: options.status,
-            content: planContent,
-          });
+          if (existingPlan) {
+            // Update existing plan
+            const updatePromise = new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(() => {
+                reject(
+                  new CliError(
+                    ErrorCodes.INTERNAL_ERROR,
+                    'Update confirmation timed out after 5 seconds',
+                  ),
+                );
+              }, 5000);
 
-          await insertPromise;
+              conn.db.plan.onUpdate((_ctx: any, _oldRow: any, newRow: any) => {
+                if (newRow.id === existingPlan!.id) {
+                  clearTimeout(timer);
+                  resolve();
+                }
+              });
+            });
 
-          // Find the inserted plan to get its ID
+            conn.reducers.updatePlan({
+              planId: existingPlan.id,
+              planNumber: planNumberBigInt,
+              type: options.type,
+              wave: BigInt(options.wave),
+              dependsOn: options.dependsOn,
+              objective: options.objective,
+              autonomous: options.autonomous,
+              requirements: options.requirements,
+              status: options.status,
+              content: planContent,
+            });
+
+            await updatePromise;
+          } else {
+            // Insert new plan
+            const insertPromise = waitForInsert(
+              conn,
+              conn.db.plan,
+              (row) =>
+                row.phaseId === phase.id &&
+                row.planNumber === planNumberBigInt,
+            );
+
+            conn.reducers.insertPlan({
+              phaseId: phase.id,
+              planNumber: planNumberBigInt,
+              type: options.type,
+              wave: BigInt(options.wave),
+              dependsOn: options.dependsOn,
+              objective: options.objective,
+              autonomous: options.autonomous,
+              requirements: options.requirements,
+              status: options.status,
+              content: planContent,
+            });
+
+            await insertPromise;
+          }
+
+          // Find the plan to get its ID
           let insertedPlan = null;
           for (const row of conn.db.plan.iter()) {
             if (
               row.phaseId === phase.id &&
-              row.planNumber === BigInt(options.plan)
+              row.planNumber === planNumberBigInt
             ) {
               insertedPlan = row;
               break;
@@ -185,8 +235,24 @@ export function registerWritePlanCommand(program: Command): void {
           if (!insertedPlan) {
             throw new CliError(
               ErrorCodes.INTERNAL_ERROR,
-              'Plan insert confirmed but row not found',
+              'Plan write confirmed but row not found',
             );
+          }
+
+          // On update, delete existing tasks and must-haves before re-inserting
+          if (existingPlan) {
+            for (const row of conn.db.planTask.iter()) {
+              if (row.planId === insertedPlan.id) {
+                conn.reducers.deletePlanTask({ taskId: row.id });
+              }
+            }
+            for (const row of conn.db.mustHave.iter()) {
+              if (row.planId === insertedPlan.id) {
+                conn.reducers.deleteMustHave({ mustHaveId: row.id });
+              }
+            }
+            // Brief wait for deletes to propagate
+            await new Promise((resolve) => setTimeout(resolve, 500));
           }
 
           // Insert tasks if provided

--- a/src/cli/lib/connection.ts
+++ b/src/cli/lib/connection.ts
@@ -3,9 +3,13 @@ import {
   type ErrorContext,
   type SubscriptionEventContext,
 } from '../../module_bindings/index.js';
+import { setGlobalLogLevel } from 'spacetimedb';
 import { CliError, ErrorCodes } from './errors.js';
 import { requireConfig } from './config.js';
 import { getGitRemoteUrl } from './git.js';
+
+// Suppress SDK info logs (they go to stdout and pollute JSON output)
+setGlobalLogLevel('error');
 
 export async function withConnection<T>(
   fn: (conn: DbConnection) => T | Promise<T>,

--- a/src/module_bindings/index.ts
+++ b/src/module_bindings/index.ts
@@ -118,13 +118,13 @@ const tablesSchema = __schema({
   codebases: __table({
     name: 'codebase_map',
     indexes: [
-      { name: 'codebase_map_doc_type', algorithm: 'btree', columns: [
+      { name: 'codebase_map_doc_type', accessor: 'codebase_map_doc_type', algorithm: 'btree', columns: [
         'docType',
       ] },
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'codebase_map_project_id', algorithm: 'btree', columns: [
+      { name: 'codebase_map_project_id', accessor: 'codebase_map_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -135,10 +135,10 @@ const tablesSchema = __schema({
   config: __table({
     name: 'config',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'config_project_id', algorithm: 'btree', columns: [
+      { name: 'config_project_id', accessor: 'config_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -149,10 +149,10 @@ const tablesSchema = __schema({
   continueHere: __table({
     name: 'continue_here',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'continue_here_project_id', algorithm: 'btree', columns: [
+      { name: 'continue_here_project_id', accessor: 'continue_here_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -163,13 +163,13 @@ const tablesSchema = __schema({
   debugSession: __table({
     name: 'debug_session',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'debug_session_project_id', algorithm: 'btree', columns: [
+      { name: 'debug_session_project_id', accessor: 'debug_session_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
-      { name: 'debug_session_status', algorithm: 'btree', columns: [
+      { name: 'debug_session_status', accessor: 'debug_session_status', algorithm: 'btree', columns: [
         'status',
       ] },
     ],
@@ -180,13 +180,13 @@ const tablesSchema = __schema({
   milestone: __table({
     name: 'milestone',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'milestone_project_id', algorithm: 'btree', columns: [
+      { name: 'milestone_project_id', accessor: 'milestone_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
-      { name: 'milestone_status', algorithm: 'btree', columns: [
+      { name: 'milestone_status', accessor: 'milestone_status', algorithm: 'btree', columns: [
         'status',
       ] },
     ],
@@ -197,16 +197,16 @@ const tablesSchema = __schema({
   milestoneAudit: __table({
     name: 'milestone_audit',
     indexes: [
-      { name: 'milestone_audit_status', algorithm: 'btree', columns: [
+      { name: 'milestone_audit_status', accessor: 'milestone_audit_status', algorithm: 'btree', columns: [
         'auditStatus',
       ] },
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'milestone_audit_milestone_id', algorithm: 'btree', columns: [
+      { name: 'milestone_audit_milestone_id', accessor: 'milestone_audit_milestone_id', algorithm: 'btree', columns: [
         'milestoneId',
       ] },
-      { name: 'milestone_audit_project_id', algorithm: 'btree', columns: [
+      { name: 'milestone_audit_project_id', accessor: 'milestone_audit_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -217,10 +217,10 @@ const tablesSchema = __schema({
   mustHave: __table({
     name: 'must_have',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'must_have_plan_id', algorithm: 'btree', columns: [
+      { name: 'must_have_plan_id', accessor: 'must_have_plan_id', algorithm: 'btree', columns: [
         'planId',
       ] },
     ],
@@ -231,10 +231,10 @@ const tablesSchema = __schema({
   phase: __table({
     name: 'phase',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'phase_project_id', algorithm: 'btree', columns: [
+      { name: 'phase_project_id', accessor: 'phase_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -245,10 +245,10 @@ const tablesSchema = __schema({
   phaseContext: __table({
     name: 'phase_context',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'phase_context_phase_id', algorithm: 'btree', columns: [
+      { name: 'phase_context_phase_id', accessor: 'phase_context_phase_id', algorithm: 'btree', columns: [
         'phaseId',
       ] },
     ],
@@ -259,10 +259,10 @@ const tablesSchema = __schema({
   plan: __table({
     name: 'plan',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'plan_phase_id', algorithm: 'btree', columns: [
+      { name: 'plan_phase_id', accessor: 'plan_phase_id', algorithm: 'btree', columns: [
         'phaseId',
       ] },
     ],
@@ -273,10 +273,10 @@ const tablesSchema = __schema({
   planSummary: __table({
     name: 'plan_summary',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'plan_summary_plan_id', algorithm: 'btree', columns: [
+      { name: 'plan_summary_plan_id', accessor: 'plan_summary_plan_id', algorithm: 'btree', columns: [
         'planId',
       ] },
     ],
@@ -287,10 +287,10 @@ const tablesSchema = __schema({
   planTask: __table({
     name: 'plan_task',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'plan_task_plan_id', algorithm: 'btree', columns: [
+      { name: 'plan_task_plan_id', accessor: 'plan_task_plan_id', algorithm: 'btree', columns: [
         'planId',
       ] },
     ],
@@ -301,10 +301,10 @@ const tablesSchema = __schema({
   project: __table({
     name: 'project',
     indexes: [
-      { name: 'git_remote_url', algorithm: 'btree', columns: [
+      { name: 'git_remote_url', accessor: 'git_remote_url', algorithm: 'btree', columns: [
         'gitRemoteUrl',
       ] },
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
     ],
@@ -316,10 +316,10 @@ const tablesSchema = __schema({
   projectState: __table({
     name: 'project_state',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'project_state_project_id', algorithm: 'btree', columns: [
+      { name: 'project_state_project_id', accessor: 'project_state_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -330,10 +330,10 @@ const tablesSchema = __schema({
   requirement: __table({
     name: 'requirement',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'requirement_project_id', algorithm: 'btree', columns: [
+      { name: 'requirement_project_id', accessor: 'requirement_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -344,10 +344,10 @@ const tablesSchema = __schema({
   research: __table({
     name: 'research',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'research_phase_id', algorithm: 'btree', columns: [
+      { name: 'research_phase_id', accessor: 'research_phase_id', algorithm: 'btree', columns: [
         'phaseId',
       ] },
     ],
@@ -358,13 +358,13 @@ const tablesSchema = __schema({
   sessionCheckpoint: __table({
     name: 'session_checkpoint',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'session_checkpoint_phase_id', algorithm: 'btree', columns: [
+      { name: 'session_checkpoint_phase_id', accessor: 'session_checkpoint_phase_id', algorithm: 'btree', columns: [
         'phaseId',
       ] },
-      { name: 'session_checkpoint_project_id', algorithm: 'btree', columns: [
+      { name: 'session_checkpoint_project_id', accessor: 'session_checkpoint_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
     ],
@@ -375,16 +375,16 @@ const tablesSchema = __schema({
   todo: __table({
     name: 'todo',
     indexes: [
-      { name: 'todo_area', algorithm: 'btree', columns: [
+      { name: 'todo_area', accessor: 'todo_area', algorithm: 'btree', columns: [
         'area',
       ] },
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'todo_project_id', algorithm: 'btree', columns: [
+      { name: 'todo_project_id', accessor: 'todo_project_id', algorithm: 'btree', columns: [
         'projectId',
       ] },
-      { name: 'todo_status', algorithm: 'btree', columns: [
+      { name: 'todo_status', accessor: 'todo_status', algorithm: 'btree', columns: [
         'status',
       ] },
     ],
@@ -395,10 +395,10 @@ const tablesSchema = __schema({
   verification: __table({
     name: 'verification',
     indexes: [
-      { name: 'id', algorithm: 'btree', columns: [
+      { name: 'id', accessor: 'id', algorithm: 'btree', columns: [
         'id',
       ] },
-      { name: 'verification_phase_id', algorithm: 'btree', columns: [
+      { name: 'verification_phase_id', accessor: 'verification_phase_id', algorithm: 'btree', columns: [
         'phaseId',
       ] },
     ],


### PR DESCRIPTION
## Summary

- **write-plan**: Check for existing plan before inserting — update in place instead of creating duplicates for the same `(phase, planNumber)`. Cleans up stale tasks and must-haves on update.
- **init**: Deduplicate plan entries by `planNumber` (keep latest `id`) in `progress`, `plan-phase`, and `get-phase` subcommands. Add `--slim` flag to `get-phase` to omit plan content.
- **connection**: Suppress SpacetimeDB SDK info logs that pollute JSON CLI output.
- **module_bindings**: Add `accessor` fields to index definitions (regenerated bindings).

## Test plan

- [ ] Run `stclaude write-plan` for a new plan — verify insert works
- [ ] Run `stclaude write-plan` again for same phase/planNumber — verify update (no duplicate row)
- [ ] Run `stclaude init progress` — verify plan counts are correct (no duplicates)
- [ ] Run `stclaude init get-phase <N>` — verify no duplicate plan entries
- [ ] Run `stclaude init get-phase <N> --slim` — verify content is omitted
- [ ] Verify CLI JSON output has no SDK info log pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)