### PR TITLE
fix: Windows path quoting and cross-platform patch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "spacetime:publish:local": "spacetime publish --module-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --module-path spacetimedb --server maincloud",
     "build:cli": "node scripts/build.mjs",
-    "install:cli": "npm run build:cli && node scripts/install.mjs"
+    "install:cli": "npm run build:cli && node scripts/install.mjs",
+    "patch-gsd": "node scripts/patch-gsd-files.mjs"
   },
   "dependencies": {
     "commander": "^14.0.3",

--- a/scripts/patch-gsd-files.mjs
+++ b/scripts/patch-gsd-files.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform script to add stgsd integration blocks to GSD workflow files.
+ * Replaces the bash-only patch-gsd-files.sh for Windows compatibility.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const HOME = homedir();
+const GSD = join(HOME, '.claude', 'get-shit-done');
+const AGENTS = join(HOME, '.claude', 'agents');
+const COMMANDS = join(HOME, '.claude', 'commands');
+
+function patchFile(filePath, block) {
+  if (!existsSync(filePath)) {
+    console.log(`SKIP (not found): ${filePath}`);
+    return;
+  }
+
+  const content = readFileSync(filePath, 'utf-8');
+  if (/stgsd-sync|stgsd-note|zero-pad for stgsd/.test(content)) {
+    console.log(`ALREADY PATCHED: ${filePath}`);
+    return;
+  }
+
+  writeFileSync(filePath, content + '\n' + block + '\n');
+  console.log(`PATCHED: ${filePath}`);
+}
+
+// --- GSD Workflows ---
+
+patchFile(join(GSD, 'workflows', 'plan-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init plan-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd get-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-context --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd write-research --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'execute-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd get-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd complete-phase --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd write-verification --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd read-plan --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'transition.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd complete-phase --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd update-progress --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'execute-plan.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-summary --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd advance-plan --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd record-metric --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd mark-requirement --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'progress.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init progress --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'map-codebase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-codebase-map --json 2>/dev/null || true
+~/.claude/bin/stgsd write-codebase-map 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'verify-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-verification --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'remove-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+~/.claude/bin/stgsd remove-phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'discuss-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init plan-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd get-codebase-map --json 2>/dev/null || true
+~/.claude/bin/stgsd write-context --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'add-todo.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd list-todos --json 2>/dev/null || true
+~/.claude/bin/stgsd add-todo 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'verify-work.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'resume-project.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd get-session --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'check-todos.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd list-todos --json 2>/dev/null || true
+~/.claude/bin/stgsd complete-todo 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'audit-milestone.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-audit 2>/dev/null || true
+~/.claude/bin/stgsd get-milestones --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'quick.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'pause-work.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-session 2>/dev/null || true
+~/.claude/bin/stgsd get-session --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'list-phase-assumptions.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'diagnose-issues.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-debug 2>/dev/null || true
+~/.claude/bin/stgsd get-debug --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'plan-milestone-gaps.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+~/.claude/bin/stgsd add-phase 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'insert-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd insert-phase 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'add-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd add-phase 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'research-phase.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init plan-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-research --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'new-milestone.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-milestones --json 2>/dev/null || true
+~/.claude/bin/stgsd get-milestones --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'complete-milestone.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-milestone 2>/dev/null || true
+~/.claude/bin/stgsd write-audit 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(GSD, 'workflows', 'health.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd health validation 2>/dev/null || true
+~/.claude/bin/stgsd health 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+// --- GSD References & Templates ---
+
+patchFile(join(GSD, 'references', 'phase-argument-parsing.md'),
+`<stgsd-note>
+Phase numbers are passed as plain integers to stgsd: \`stgsd get-phase 3\` (not \`stgsd get-phase 03\`).
+Do not zero-pad for stgsd commands; pass plain integer values.
+</stgsd-note>`);
+
+patchFile(join(GSD, 'templates', 'debug-subagent-prompt.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-debug 2>/dev/null || true
+~/.claude/bin/stgsd get-debug --json 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+// --- Agent Files ---
+
+patchFile(join(AGENTS, 'gsd-executor.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-summary --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd advance-plan --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd update-progress --json 2>/dev/null || true
+~/.claude/bin/stgsd mark-requirement 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(AGENTS, 'gsd-planner.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init plan-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-plan --phase "$PHASE" 2>/dev/null || true
+~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd read-plan --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(AGENTS, 'gsd-verifier.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd init execute-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-verification --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(AGENTS, 'gsd-phase-researcher.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd init plan-phase "$PHASE" --json 2>/dev/null || true
+~/.claude/bin/stgsd write-research --phase "$PHASE" 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+patchFile(join(AGENTS, 'gsd-codebase-mapper.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd write-codebase-map --type tech 2>/dev/null || true
+~/.claude/bin/stgsd write-codebase-map 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+// --- Command Files ---
+
+patchFile(join(COMMANDS, 'gsd', 'debug.md'),
+`<stgsd-sync>
+\`\`\`bash
+~/.claude/bin/stgsd get-debug --json 2>/dev/null || true
+~/.claude/bin/stgsd get-state --json 2>/dev/null || true
+~/.claude/bin/stgsd write-debug 2>/dev/null || true
+\`\`\`
+</stgsd-sync>`);
+
+console.log('Done patching all files');

--- a/src/cli/commands/seed.ts
+++ b/src/cli/commands/seed.ts
@@ -7,6 +7,7 @@ import { findProjectByGitRemote } from '../lib/project.js';
 import { computeRepoId, databaseName, modulePath, loadConfig } from '../lib/config.js';
 import { outputSuccess, outputError } from '../lib/output.js';
 import { CliError, ErrorCodes } from '../lib/errors.js';
+import { resolveSpacetimeBin, shellQuote } from '../lib/spacetime.js';
 
 interface SeedData {
   project: { id: bigint; name: string; gitRemoteUrl: string };
@@ -33,24 +34,10 @@ function wipeDatabase(gitRemoteUrl: string): void {
     );
   }
 
-  let spacetimeBin: string;
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where spacetime' : 'which spacetime';
-    const shellOpt = process.platform === 'win32' ? undefined : (process.env.SHELL || '/bin/sh');
-    spacetimeBin = execSync(whichCmd, {
-      encoding: 'utf-8',
-      ...(shellOpt ? { shell: shellOpt } : {}),
-      timeout: 5000,
-    }).trim().split('\n')[0].trim();
-  } catch {
-    throw new CliError(
-      ErrorCodes.INTERNAL_ERROR,
-      'spacetime CLI not found. Install SpacetimeDB: https://spacetimedb.com/install',
-    );
-  }
+  const spacetimeBin = resolveSpacetimeBin();
 
   const dbName = databaseName(repoId);
-  const publishCmd = `${spacetimeBin} publish ${dbName} --delete-data=always -y --module-path ${modulePath()} --server local --no-config`;
+  const publishCmd = `${shellQuote(spacetimeBin)} publish ${dbName} --delete-data=always -y --module-path ${shellQuote(modulePath())} --server local --no-config`;
   try {
     execSync(publishCmd, { stdio: 'pipe', timeout: 60_000 });
   } catch (err) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,6 +11,7 @@ import {
 } from '../lib/config.js';
 import { outputSuccess, outputError } from '../lib/output.js';
 import { CliError, ErrorCodes } from '../lib/errors.js';
+import { resolveSpacetimeBin, shellQuote } from '../lib/spacetime.js';
 
 interface SetupResult {
   repoId: string;
@@ -80,25 +81,11 @@ export function registerSetupCommand(program: Command): void {
         }
 
         // Resolve spacetime binary — execSync doesn't inherit full shell PATH
-        let spacetimeBin: string;
-        try {
-          const whichCmd = process.platform === 'win32' ? 'where spacetime' : 'which spacetime';
-          const shellOpt = process.platform === 'win32' ? undefined : (process.env.SHELL || '/bin/sh');
-          spacetimeBin = execSync(whichCmd, {
-            encoding: 'utf-8',
-            ...(shellOpt ? { shell: shellOpt } : {}),
-            timeout: 5000,
-          }).trim().split('\n')[0].trim();
-        } catch {
-          throw new CliError(
-            ErrorCodes.INTERNAL_ERROR,
-            'spacetime CLI not found. Install SpacetimeDB: https://spacetimedb.com/install',
-          );
-        }
+        const spacetimeBin = resolveSpacetimeBin();
 
         // Verify local SpacetimeDB is running
         try {
-          execSync(`${spacetimeBin} server ping local`, {
+          execSync(`${shellQuote(spacetimeBin)} server ping local`, {
             stdio: 'pipe',
             timeout: 5000,
           });
@@ -110,7 +97,7 @@ export function registerSetupCommand(program: Command): void {
         }
 
         // Publish module (--no-config avoids picking up spacetime.json from cwd)
-        const publishCmd = `${spacetimeBin} publish ${dbName} --module-path ${modulePath()} --server local --no-config`;
+        const publishCmd = `${shellQuote(spacetimeBin)} publish ${dbName} --module-path ${shellQuote(modulePath())} --server local --no-config`;
         try {
           execSync(publishCmd, { stdio: 'pipe', timeout: 60_000 });
         } catch (err) {

--- a/src/cli/lib/spacetime.ts
+++ b/src/cli/lib/spacetime.ts
@@ -3,10 +3,27 @@ import { CliError, ErrorCodes } from './errors.js';
 
 /**
  * Quote a path for use in shell commands.
- * Wraps in double quotes to handle spaces and special characters.
+ *
+ * On POSIX shells, wraps in single quotes and escapes embedded single quotes
+ * so that the argument is not subject to variable or command expansion.
+ *
+ * On Windows (cmd.exe), wraps in double quotes, escapes embedded double quotes
+ * by doubling them, and doubles '%' characters to prevent environment variable
+ * expansion (e.g. %VAR%).
  */
 export function shellQuote(p: string): string {
-  return `"${p}"`;
+  const isWindows = process.platform === 'win32';
+
+  if (isWindows) {
+    // For cmd.exe: escape " as "" and % as %% inside a double-quoted string.
+    const escaped = p.replace(/"/g, '""').replace(/%/g, '%%');
+    return `"${escaped}"`;
+  }
+
+  // For POSIX shells: use single quotes and escape embedded single quotes.
+  // Pattern: 'foo'\''bar' is interpreted as foo'bar.
+  const escaped = p.replace(/'/g, `'\\''`);
+  return `'${escaped}'`;
 }
 
 /**

--- a/src/cli/lib/spacetime.ts
+++ b/src/cli/lib/spacetime.ts
@@ -1,0 +1,33 @@
+import { execSync } from 'node:child_process';
+import { CliError, ErrorCodes } from './errors.js';
+
+/**
+ * Quote a path for use in shell commands.
+ * Wraps in double quotes to handle spaces and special characters.
+ */
+export function shellQuote(p: string): string {
+  return `"${p}"`;
+}
+
+/**
+ * Resolve the spacetime CLI binary path.
+ * Uses `where` on Windows, `which` on Unix.
+ */
+export function resolveSpacetimeBin(): string {
+  const isWindows = process.platform === 'win32';
+  const whichCmd = isWindows ? 'where spacetime' : 'which spacetime';
+  const shellOpt = isWindows ? undefined : (process.env.SHELL || '/bin/sh');
+
+  try {
+    return execSync(whichCmd, {
+      encoding: 'utf-8',
+      ...(shellOpt ? { shell: shellOpt } : {}),
+      timeout: 5000,
+    }).trim().split('\n')[0].trim();
+  } catch {
+    throw new CliError(
+      ErrorCodes.INTERNAL_ERROR,
+      'spacetime CLI not found. Install SpacetimeDB: https://spacetimedb.com/install',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Quote all paths interpolated into shell commands (`setup.ts`, `seed.ts`) so paths with spaces don't break on Windows
- Extract duplicated spacetime binary resolution into shared `lib/spacetime.ts` (`resolveSpacetimeBin()`, `shellQuote()`)
- Add `scripts/patch-gsd-files.mjs` — Node.js replacement for bash-only `patch-gsd-files.sh`, runnable from any shell (cmd.exe, PowerShell, Git Bash, Unix)
- Add `npm run patch-gsd` script

## Test plan
- [x] `node scripts/build.mjs` succeeds
- [x] `node scripts/install.mjs` creates correct wrappers on Windows
- [x] `stgsd setup --force` publishes module with quoted paths
- [x] `node scripts/patch-gsd-files.mjs` patches all 33 files and is idempotent
- [x] No changes to Unix behavior — quoting and `which` fallback preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)