### PR TITLE
fix: restrict Commander.js --version to -V to unblock subcommands

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,7 +38,7 @@ import { registerVerifyPatchesCommand } from './commands/verify-patches.js';
 const program = new Command()
   .name('stgsd')
   .description('stgsd - structured project state for Claude Code agents')
-  .version('0.0.1')
+  .version('0.0.1', '-V')
   .option('--json', 'Output machine-readable JSON envelope', false);
 
 registerStatusCommand(program);


### PR DESCRIPTION
## Summary
- Restricts Commander.js global `--version` flag to `-V` only, freeing `--version` for use by `write-audit` and `write-milestone` subcommands
- Previously, `stgsd write-audit --version "v1.0" ...` would print `0.0.1` and exit without persisting data
- One-line fix in `src/cli/index.ts`: `.version('0.0.1')` → `.version('0.0.1', '-V')`

Closes #15

## Test plan
- [x] `-V` on root command prints `0.0.1`
- [x] `--version` on root command is now rejected as unknown option
- [x] `write-milestone --version "v1.0" ...` reaches the subcommand action (no longer intercepted)
- [x] `write-audit --version "v1.0" ...` reaches the subcommand action (no longer intercepted)
- [x] CLI builds successfully