### PR TITLE
fix: sync audit/gap-closure workflows with SpacetimeDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 *.local.json
 .windsurfrules
+package-lock.json
+.claude/

--- a/patch-manifest.json
+++ b/patch-manifest.json
@@ -112,7 +112,9 @@
     "workflows/audit-milestone.md": {
       "expected": [
         "stgsd write-audit",
-        "stgsd get-milestones"
+        "stgsd get-milestones",
+        "stclaude write-audit",
+        "stclaude get-milestones"
       ],
       "forbidden": []
     },
@@ -147,9 +149,13 @@
     "workflows/plan-milestone-gaps.md": {
       "expected": [
         "stgsd roadmap analyze",
-        "stgsd add-phase"
+        "stgsd add-phase",
+        "stgsd get-milestones",
+        "stclaude get-milestones"
       ],
-      "forbidden": []
+      "forbidden": [
+        "v*-MILESTONE-AUDIT.md"
+      ]
     },
     "workflows/insert-phase.md": {
       "expected": [

--- a/scripts/patch-gsd-files.sh
+++ b/scripts/patch-gsd-files.sh
@@ -186,6 +186,7 @@ patch_file "$GSD/workflows/diagnose-issues.md" \
 patch_file "$GSD/workflows/plan-milestone-gaps.md" \
 '<stgsd-sync>
 ```bash
+~/.claude/bin/stgsd get-milestones --json 2>/dev/null || true
 ~/.claude/bin/stgsd roadmap analyze --json 2>/dev/null || true
 ~/.claude/bin/stgsd add-phase 2>/dev/null || true
 ```


### PR DESCRIPTION
## Summary
- Adds `stclaude write-audit` and `stclaude get-milestones` to patch manifest expected patterns for `audit-milestone.md`, verifying the native GSD workflow uses SpacetimeDB
- Adds `stclaude get-milestones` to expected and `v*-MILESTONE-AUDIT.md` to forbidden for `plan-milestone-gaps.md`, ensuring the workflow reads from SpacetimeDB not disk
- Adds `stgsd get-milestones` to the `plan-milestone-gaps` patch block in `patch-gsd-files.sh` so gap closure can retrieve audit data via stgsd integration
- Fixes stale `MILESTONE-AUDIT.md` references in the installed GSD workflow purpose/success criteria text

Closes #16

## Context
Issue #15 (merged in #17) fixed the `--version` flag conflict that prevented `write-audit` from persisting data. This PR fixes the remaining workflow disconnect: `plan-milestone-gaps` was looking for audit data on disk (`v*-MILESTONE-AUDIT.md`) instead of in SpacetimeDB where `audit-milestone` writes it.

## Test plan
- [x] `patch-manifest.json` is valid JSON
- [x] CLI builds successfully (`npm run build:cli`)
- [x] `verify-patches` correctly identifies `stclaude get-milestones` as present in both workflow files
- [x] `verify-patches` confirms `v*-MILESTONE-AUDIT.md` is absent from `plan-milestone-gaps.md`
- [ ] Run `patch-gsd-files.sh` and verify `stgsd get-milestones` appears in plan-milestone-gaps patch block