### PR TITLE
fix: return latest audit fields from get-milestones (#19)

### DIFF
--- a/src/cli/commands/get-milestones.ts
+++ b/src/cli/commands/get-milestones.ts
@@ -16,6 +16,14 @@ interface MilestoneRow {
   requirementCount: string;
   accomplishments: string;
   status: string;
+  auditStatus?: string;
+  requirementScores?: string;
+  integrationScores?: string;
+  flowScores?: string;
+  techDebtItems?: string;
+  roadmapContent?: string;
+  requirementsContent?: string;
+  auditUpdatedAt?: string;
 }
 
 function formatGetMilestones(data: unknown): string {
@@ -23,9 +31,10 @@ function formatGetMilestones(data: unknown): string {
   if (milestones.length === 0) {
     return 'No milestones found.';
   }
-  return milestones.map(m =>
-    `${m.version} — ${m.name} (${m.shippedDate}) [${m.status}]`
-  ).join('\n');
+  return milestones.map(m => {
+    const line = `${m.version} — ${m.name} (${m.shippedDate}) [${m.status}]`;
+    return m.auditStatus ? `${line} audit: ${m.auditStatus}` : line;
+  }).join('\n');
 }
 
 export function registerGetMilestonesCommand(program: Command): void {
@@ -39,22 +48,61 @@ export function registerGetMilestonesCommand(program: Command): void {
 
         const result = await withConnection((conn: DbConnection) => {
           const project = findProjectByGitRemote(conn, gitRemoteUrl);
-          const milestones: MilestoneRow[] = [];
 
-          for (const row of conn.db.milestone.iter()) {
-            if (row.projectId === project.id) {
-              milestones.push({
-                id: row.id.toString(),
-                version: row.version,
-                name: row.name,
-                shippedDate: row.shippedDate,
-                phaseCount: row.phaseCount.toString(),
-                planCount: row.planCount.toString(),
-                requirementCount: row.requirementCount.toString(),
-                accomplishments: row.accomplishments,
-                status: row.status,
+          // Index audits by milestoneId, keeping the most recently updated one
+          const latestAuditByMilestone = new Map<bigint, {
+            auditStatus: string;
+            requirementScores: string;
+            integrationScores: string;
+            flowScores: string;
+            techDebtItems: string;
+            roadmapContent: string;
+            requirementsContent: string;
+            updatedAt: bigint;
+          }>();
+          for (const audit of conn.db.milestoneAudit.iter()) {
+            if (audit.projectId !== project.id) continue;
+            const current = latestAuditByMilestone.get(audit.milestoneId);
+            const updatedAt = audit.updatedAt.microsSinceUnixEpoch;
+            if (!current || updatedAt > current.updatedAt) {
+              latestAuditByMilestone.set(audit.milestoneId, {
+                auditStatus: audit.auditStatus,
+                requirementScores: audit.requirementScores,
+                integrationScores: audit.integrationScores,
+                flowScores: audit.flowScores,
+                techDebtItems: audit.techDebtItems,
+                roadmapContent: audit.roadmapContent,
+                requirementsContent: audit.requirementsContent,
+                updatedAt,
               });
             }
+          }
+
+          const milestones: MilestoneRow[] = [];
+          for (const row of conn.db.milestone.iter()) {
+            if (row.projectId !== project.id) continue;
+            const audit = latestAuditByMilestone.get(row.id);
+            milestones.push({
+              id: row.id.toString(),
+              version: row.version,
+              name: row.name,
+              shippedDate: row.shippedDate,
+              phaseCount: row.phaseCount.toString(),
+              planCount: row.planCount.toString(),
+              requirementCount: row.requirementCount.toString(),
+              accomplishments: row.accomplishments,
+              status: row.status,
+              ...(audit && {
+                auditStatus: audit.auditStatus,
+                requirementScores: audit.requirementScores,
+                integrationScores: audit.integrationScores,
+                flowScores: audit.flowScores,
+                techDebtItems: audit.techDebtItems,
+                roadmapContent: audit.roadmapContent,
+                requirementsContent: audit.requirementsContent,
+                auditUpdatedAt: new Date(Number(audit.updatedAt / 1000n)).toISOString(),
+              }),
+            });
           }
 
           // Sort by shipped_date descending (most recent first)


### PR DESCRIPTION
## Summary
- Joins each milestone with its most recently updated `milestone_audit` row (scoped by `projectId`) in `stgsd get-milestones`
- Surfaces `auditStatus`, `requirementScores`, `integrationScores`, `flowScores`, `techDebtItems`, `roadmapContent`, `requirementsContent`, and `auditUpdatedAt` on each milestone
- Scores/tech-debt remain JSON strings (matching how `write-audit` stores them); consumers `JSON.parse()` as before

## Why
`/gsd:plan-milestone-gaps` depends on reading the canonical audit payload from SpacetimeDB via `get-milestones`. Before this change those fields were never returned, so the gap-closure workflow had nothing to parse after `/gsd:audit-milestone` completed.

Closes #19

## Test plan
- [ ] In a stgsd-configured repo: run \`stgsd write-audit ...\` then \`stgsd get-milestones --json\` and confirm the seven audit fields + \`auditUpdatedAt\` appear on the audited milestone
- [ ] Run \`stgsd get-milestones --json\` on a milestone with no audit and confirm audit fields are absent (not \`null\`/empty)
- [ ] Write two audits for the same milestone and confirm only the most recently updated one is returned
- [ ] Run \`/gsd:plan-milestone-gaps\` end-to-end and confirm it can parse \`requirement_scores.unsatisfied_ids\`, \`integration_scores.gaps\`, \`flow_scores.broken\`, and \`tech_debt_items\` from the response