### PR TITLE
fix: case-insensitive match for prefixed phase artifacts in doctor

### DIFF
--- a/src/cli/lib/disk-artifacts.ts
+++ b/src/cli/lib/disk-artifacts.ts
@@ -133,10 +133,10 @@ function findArtifact(phaseDir: string, kind: string): string | null {
     return null;
   }
   const upper = kind.toUpperCase();
-  const tail = `-${upper}.md`;
-  const exact = `${upper}.md`;
+  const tail = `-${upper}.MD`;
+  const exact = `${upper}.MD`;
   const match =
-    entries.find((e) => e === exact) ??
+    entries.find((e) => e.toUpperCase() === exact) ??
     entries.find((e) => e.toUpperCase().endsWith(tail));
   return match ? join(phaseDir, match) : null;
 }


### PR DESCRIPTION
## Summary
- `doctor`'s `findArtifact()` uppercased directory entries but compared against a lowercase `.md` tail, so prefixed phase artifacts (`01-SUMMARY.md`, `01-VERIFICATION.md`) never matched and doctor kept reporting them missing.
- Fix: build `tail`/`exact` with `.MD` and uppercase both sides of the exact-match comparison so the prefixed-artifact branch is reachable. Bare `SUMMARY.md` is still preferred when both forms exist.

## Test plan
- [x] `node scripts/build.mjs` builds without errors
- [x] Manual repro against a phase dir containing `01-SUMMARY.md` / `01-VERIFICATION.md` — both resolve via `findArtifact`
- [x] Bare `SUMMARY.md` still wins when both prefixed and unprefixed exist
- [ ] `stclaude doctor` against a real phase that has `01-SUMMARY.md` / `01-VERIFICATION.md` reports clean

Closes #23