### PR TITLE
fix: resolve archived phase dirs in doctor and find-phase (#25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "spacetime:publish": "spacetime publish --module-path spacetimedb --server maincloud",
     "build:cli": "node scripts/build.mjs",
     "install:cli": "npm run build:cli && node scripts/install.mjs",
-    "patch-gsd": "node scripts/patch-gsd-files.mjs"
+    "patch-gsd": "node scripts/patch-gsd-files.mjs",
+    "test": "bun test"
   },
   "dependencies": {
     "commander": "^14.0.3",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,6 +17,7 @@ interface PhaseFinding {
   phase: string;
   name?: string;
   source: 'stdb' | 'disk';
+  severity: 'error' | 'info';
   issue: string;
   remediation: string;
 }
@@ -28,6 +29,7 @@ interface DoctorData {
   summary: {
     stdbPhases: number;
     diskPhases: number;
+    archivedPhases: number;
     findings: number;
   };
 }
@@ -36,20 +38,29 @@ function formatDoctor(data: unknown): string {
   const { project, ok, findings, summary } = data as DoctorData;
   const lines = [
     `Doctor: ${project.name}`,
-    `  STDB phases: ${summary.stdbPhases}`,
-    `  Disk phases: ${summary.diskPhases}`,
-    `  Findings:    ${summary.findings}`,
+    `  STDB phases:     ${summary.stdbPhases}`,
+    `  Disk phases:     ${summary.diskPhases}`,
+    `  Archived phases: ${summary.archivedPhases}`,
+    `  Findings:        ${summary.findings}`,
     '',
   ];
+  const errors = findings.filter((f) => f.severity === 'error');
+  const infos = findings.filter((f) => f.severity === 'info');
   if (ok) {
     lines.push('No divergences detected.');
-    return lines.join('\n');
   }
-  for (const f of findings) {
+  for (const f of errors) {
     lines.push(`[${f.source.toUpperCase()}] phase ${f.phase}${f.name ? ` (${f.name})` : ''}`);
     lines.push(`  Issue:   ${f.issue}`);
     lines.push(`  Suggest: ${f.remediation}`);
     lines.push('');
+  }
+  if (infos.length > 0) {
+    if (!ok || errors.length === 0) lines.push('');
+    lines.push('Info:');
+    for (const f of infos) {
+      lines.push(`  - phase ${f.phase}${f.name ? ` (${f.name})` : ''}: ${f.issue}`);
+    }
   }
   return lines.join('\n').trimEnd();
 }
@@ -98,16 +109,31 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
+                severity: 'error',
                 issue: 'Marked Complete in SpacetimeDB but phase directory missing on disk',
                 remediation: `Run /gsd:verify-work to retroactively produce artifacts, or stclaude remove-phase ${p.number} to roll STDB back`,
               });
               continue;
+            }
+            if (artifacts.location === 'archived') {
+              const versionLabel = artifacts.milestoneVersion
+                ? `milestone v${artifacts.milestoneVersion}`
+                : 'an archived milestone';
+              findings.push({
+                phase: p.number,
+                name: p.name,
+                source: 'disk',
+                severity: 'info',
+                issue: `Resolved from ${versionLabel} archive at ${artifacts.phaseDir}`,
+                remediation: 'No action required — archived phases are tracked under .planning/milestones/',
+              });
             }
             if (!artifacts.summaryFile) {
               findings.push({
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
+                severity: 'error',
                 issue: `Complete in STDB but SUMMARY.md missing in ${artifacts.phaseDir}`,
                 remediation: 'Run /gsd:verify-work to generate SUMMARY.md retroactively',
               });
@@ -117,6 +143,7 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
+                severity: 'error',
                 issue: `Complete in STDB but VERIFICATION.md missing in ${artifacts.phaseDir}`,
                 remediation: 'Run /gsd:verify-work to generate VERIFICATION.md retroactively',
               });
@@ -127,6 +154,7 @@ export function registerDoctorCommand(program: Command): void {
                   phase: p.number,
                   name: p.name,
                   source: 'stdb',
+                  severity: 'error',
                   issue: `Complete in STDB but VERIFICATION.md status: gaps_found at ${artifacts.verificationFile}`,
                   remediation: 'Resolve gaps then re-run write-verification, or roll back with remove-phase',
                 });
@@ -137,6 +165,7 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
+                severity: 'error',
                 issue: `Complete in STDB but VALIDATION.md missing (nyquist_validation enabled) in ${artifacts.phaseDir}`,
                 remediation: 'Run /gsd:validate-phase to fill the Nyquist validation gap',
               });
@@ -163,23 +192,33 @@ export function registerDoctorCommand(program: Command): void {
               findings.push({
                 phase: d.number,
                 source: 'disk',
+                severity: 'error',
                 issue: `Phase directory ${d.path} has no matching phase row in SpacetimeDB`,
                 remediation: 'Run stclaude add-phase / insert-phase to register it, or delete the orphan directory',
               });
             }
           }
 
+          const activeDiskPhases = diskDirs.filter(
+            (d) => d.location === 'active',
+          ).length;
+          const archivedDiskPhases = diskDirs.length - activeDiskPhases;
+          const errorCount = findings.filter(
+            (f) => f.severity === 'error',
+          ).length;
+
           return {
             project: {
               id: project.id.toString(),
               name: project.name,
             },
-            ok: findings.length === 0,
+            ok: errorCount === 0,
             findings,
             summary: {
               stdbPhases: stdbPhases.length,
-              diskPhases: diskDirs.length,
-              findings: findings.length,
+              diskPhases: activeDiskPhases,
+              archivedPhases: archivedDiskPhases,
+              findings: errorCount,
             },
           };
         });

--- a/src/cli/lib/disk-artifacts.ts
+++ b/src/cli/lib/disk-artifacts.ts
@@ -1,12 +1,16 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
+export type PhaseDirLocation = 'active' | 'archived';
+
 export interface PhaseArtifacts {
   phaseDir: string | null;
   planFile: string | null;
   summaryFile: string | null;
   verificationFile: string | null;
   validationFile: string | null;
+  location: PhaseDirLocation | null;
+  milestoneVersion: string | null;
 }
 
 export interface PhaseGateIssue {
@@ -63,59 +67,160 @@ export function comparePhaseNumber(a: string, b: string): number {
 }
 
 /**
- * Locate a phase directory under <cwd>/.planning/phases/ matching
- * the normalized phase number prefix (e.g. "04-" or exactly "04").
- * Returns null if .planning/phases is missing or no match.
+ * List archived-phase root directories under .planning/milestones/.
+ * The archived layout is `.planning/milestones/v<X.Y>-phases/<phaseDir>/`,
+ * produced by the `complete-milestone` workflow's "archive phases" option.
+ * Returns an empty list if `.planning/milestones/` is missing or contains
+ * no `v*-phases` subdirectories.
  */
-export function findPhaseDir(cwd: string, phaseNumber: string): string | null {
-  const phasesDir = join(cwd, '.planning', 'phases');
-  if (!existsSync(phasesDir)) return null;
-  const normalized = normalizePhaseNumber(phaseNumber);
+function listArchivedPhaseRoots(
+  cwd: string,
+): Array<{ path: string; version: string }> {
+  const milestonesDir = join(cwd, '.planning', 'milestones');
+  if (!existsSync(milestonesDir)) return [];
   let entries: string[];
   try {
-    entries = readdirSync(phasesDir);
+    entries = readdirSync(milestonesDir);
+  } catch {
+    return [];
+  }
+  const out: Array<{ path: string; version: string }> = [];
+  for (const name of entries) {
+    const m = name.match(/^v([0-9]+(?:\.[0-9]+)*)-phases$/i);
+    if (!m) continue;
+    const full = join(milestonesDir, name);
+    try {
+      if (!statSync(full).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    out.push({ path: full, version: m[1] });
+  }
+  return out;
+}
+
+function findPhaseDirIn(
+  root: string,
+  normalized: string,
+): string | null {
+  if (!existsSync(root)) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
   } catch {
     return null;
   }
   // Prefer exact "<N>-..." match; fall back to bare "<N>" dir.
   const withSlug = entries.find((e) => e.startsWith(normalized + '-'));
   if (withSlug) {
-    const full = join(phasesDir, withSlug);
-    if (statSync(full).isDirectory()) return full;
+    const full = join(root, withSlug);
+    try {
+      if (statSync(full).isDirectory()) return full;
+    } catch {
+      /* fall through */
+    }
   }
   const exact = entries.find((e) => e === normalized);
   if (exact) {
-    const full = join(phasesDir, exact);
-    if (statSync(full).isDirectory()) return full;
+    const full = join(root, exact);
+    try {
+      if (statSync(full).isDirectory()) return full;
+    } catch {
+      /* fall through */
+    }
   }
   return null;
 }
 
 /**
- * List all phase directories under .planning/phases/ with parsed numbers.
+ * Locate a phase directory matching the normalized phase number prefix
+ * (e.g. "04-" or exactly "04"). Searches `.planning/phases/` first, then
+ * falls back to archived milestones under `.planning/milestones/v*-phases/`.
+ * Returns null if no match is found in either location.
+ */
+export function findPhaseDir(cwd: string, phaseNumber: string): string | null {
+  return resolvePhaseDir(cwd, phaseNumber)?.path ?? null;
+}
+
+/**
+ * Locate a phase directory and report whether it lives under the active
+ * `.planning/phases/` tree or under an archived milestone tree at
+ * `.planning/milestones/v<X.Y>-phases/`. The active location is preferred;
+ * archived locations are scanned in deterministic order (newest milestone
+ * version first, by lexical sort, so v1.1 wins over v1.0).
+ */
+export function resolvePhaseDir(
+  cwd: string,
+  phaseNumber: string,
+): { path: string; location: PhaseDirLocation; milestoneVersion: string | null } | null {
+  const normalized = normalizePhaseNumber(phaseNumber);
+  const active = findPhaseDirIn(join(cwd, '.planning', 'phases'), normalized);
+  if (active) return { path: active, location: 'active', milestoneVersion: null };
+
+  const roots = listArchivedPhaseRoots(cwd).sort(
+    (a, b) => b.version.localeCompare(a.version, undefined, { numeric: true }),
+  );
+  for (const root of roots) {
+    const archived = findPhaseDirIn(root.path, normalized);
+    if (archived) {
+      return { path: archived, location: 'archived', milestoneVersion: root.version };
+    }
+  }
+  return null;
+}
+
+/**
+ * List all phase directories under .planning/phases/ and the archived
+ * milestone trees, with parsed numbers and a `location` tag. Active phases
+ * appear first in input order; archived phases follow, grouped by milestone
+ * version. Callers that only care about active phases can filter on
+ * `location === 'active'`.
  */
 export function listPhaseDirs(
   cwd: string,
-): Array<{ name: string; path: string; number: string }> {
-  const phasesDir = join(cwd, '.planning', 'phases');
-  if (!existsSync(phasesDir)) return [];
-  let entries: string[];
-  try {
-    entries = readdirSync(phasesDir);
-  } catch {
-    return [];
-  }
-  const out: Array<{ name: string; path: string; number: string }> = [];
-  for (const name of entries) {
-    const full = join(phasesDir, name);
+): Array<{
+  name: string;
+  path: string;
+  number: string;
+  location: PhaseDirLocation;
+  milestoneVersion: string | null;
+}> {
+  const out: Array<{
+    name: string;
+    path: string;
+    number: string;
+    location: PhaseDirLocation;
+    milestoneVersion: string | null;
+  }> = [];
+
+  const collect = (
+    root: string,
+    location: PhaseDirLocation,
+    milestoneVersion: string | null,
+  ): void => {
+    if (!existsSync(root)) return;
+    let entries: string[];
     try {
-      if (!statSync(full).isDirectory()) continue;
+      entries = readdirSync(root);
     } catch {
-      continue;
+      return;
     }
-    const m = name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
-    if (!m) continue;
-    out.push({ name, path: full, number: m[1] });
+    for (const name of entries) {
+      const full = join(root, name);
+      try {
+        if (!statSync(full).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      const m = name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
+      if (!m) continue;
+      out.push({ name, path: full, number: m[1], location, milestoneVersion });
+    }
+  };
+
+  collect(join(cwd, '.planning', 'phases'), 'active', null);
+  for (const root of listArchivedPhaseRoots(cwd)) {
+    collect(root.path, 'archived', root.version);
   }
   return out;
 }
@@ -145,22 +250,26 @@ export function collectPhaseArtifacts(
   cwd: string,
   phaseNumber: string,
 ): PhaseArtifacts {
-  const phaseDir = findPhaseDir(cwd, phaseNumber);
-  if (!phaseDir) {
+  const resolved = resolvePhaseDir(cwd, phaseNumber);
+  if (!resolved) {
     return {
       phaseDir: null,
       planFile: null,
       summaryFile: null,
       verificationFile: null,
       validationFile: null,
+      location: null,
+      milestoneVersion: null,
     };
   }
   return {
-    phaseDir,
-    planFile: findArtifact(phaseDir, 'PLAN'),
-    summaryFile: findArtifact(phaseDir, 'SUMMARY'),
-    verificationFile: findArtifact(phaseDir, 'VERIFICATION'),
-    validationFile: findArtifact(phaseDir, 'VALIDATION'),
+    phaseDir: resolved.path,
+    planFile: findArtifact(resolved.path, 'PLAN'),
+    summaryFile: findArtifact(resolved.path, 'SUMMARY'),
+    verificationFile: findArtifact(resolved.path, 'VERIFICATION'),
+    validationFile: findArtifact(resolved.path, 'VALIDATION'),
+    location: resolved.location,
+    milestoneVersion: resolved.milestoneVersion,
   };
 }
 

--- a/tests/disk-artifacts.test.ts
+++ b/tests/disk-artifacts.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  collectPhaseArtifacts,
+  findPhaseDir,
+  listPhaseDirs,
+  resolvePhaseDir,
+} from '../src/cli/lib/disk-artifacts';
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'stgsd-disk-artifacts-'));
+  mkdirSync(join(cwd, '.planning'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function writeFrontmatter(file: string, body: string): void {
+  writeFileSync(file, body);
+}
+
+describe('findPhaseDir / resolvePhaseDir', () => {
+  test('resolves an active phase directory under .planning/phases/', () => {
+    const dir = join(cwd, '.planning', 'phases', '01-schema-module');
+    mkdirSync(dir, { recursive: true });
+
+    const path = findPhaseDir(cwd, '01');
+    expect(path).toBe(dir);
+
+    const resolved = resolvePhaseDir(cwd, '01');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.location).toBe('active');
+    expect(resolved?.milestoneVersion).toBeNull();
+  });
+
+  test('resolves an archived phase directory under milestones/', () => {
+    const dir = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.0-phases',
+      '01-schema-module',
+    );
+    mkdirSync(dir, { recursive: true });
+
+    const path = findPhaseDir(cwd, '01');
+    expect(path).toBe(dir);
+
+    const resolved = resolvePhaseDir(cwd, '01');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.location).toBe('archived');
+    expect(resolved?.milestoneVersion).toBe('1.0');
+  });
+
+  test('prefers active over archived when both exist', () => {
+    const active = join(cwd, '.planning', 'phases', '02-active');
+    const archived = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.0-phases',
+      '02-archived',
+    );
+    mkdirSync(active, { recursive: true });
+    mkdirSync(archived, { recursive: true });
+
+    const resolved = resolvePhaseDir(cwd, '02');
+    expect(resolved?.path).toBe(active);
+    expect(resolved?.location).toBe('active');
+  });
+
+  test('prefers newest milestone version when multiple archives match', () => {
+    const v10 = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.0-phases',
+      '03-old',
+    );
+    const v11 = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.1-phases',
+      '03-newer',
+    );
+    mkdirSync(v10, { recursive: true });
+    mkdirSync(v11, { recursive: true });
+
+    const resolved = resolvePhaseDir(cwd, '03');
+    expect(resolved?.path).toBe(v11);
+    expect(resolved?.milestoneVersion).toBe('1.1');
+  });
+
+  test('accepts unpadded phase numbers', () => {
+    const dir = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.0-phases',
+      '04-foo',
+    );
+    mkdirSync(dir, { recursive: true });
+
+    expect(findPhaseDir(cwd, '4')).toBe(dir);
+  });
+
+  test('returns null when phase is in neither location', () => {
+    expect(findPhaseDir(cwd, '99')).toBeNull();
+    expect(resolvePhaseDir(cwd, '99')).toBeNull();
+  });
+
+  test('ignores non-phase directories under milestones/', () => {
+    mkdirSync(join(cwd, '.planning', 'milestones', 'v1.0-phases', '05-x'), {
+      recursive: true,
+    });
+    mkdirSync(join(cwd, '.planning', 'milestones', 'v1.0-extras'), {
+      recursive: true,
+    });
+    mkdirSync(join(cwd, '.planning', 'milestones', 'README.md'), {
+      recursive: true,
+    });
+
+    expect(findPhaseDir(cwd, '05')).toBe(
+      join(cwd, '.planning', 'milestones', 'v1.0-phases', '05-x'),
+    );
+    expect(findPhaseDir(cwd, '06')).toBeNull();
+  });
+});
+
+describe('listPhaseDirs', () => {
+  test('lists active and archived phases with location tags', () => {
+    mkdirSync(join(cwd, '.planning', 'phases', '07-current'), {
+      recursive: true,
+    });
+    mkdirSync(
+      join(cwd, '.planning', 'milestones', 'v1.0-phases', '01-old'),
+      { recursive: true },
+    );
+    mkdirSync(
+      join(cwd, '.planning', 'milestones', 'v1.0-phases', '02-old'),
+      { recursive: true },
+    );
+
+    const dirs = listPhaseDirs(cwd);
+    const active = dirs.filter((d) => d.location === 'active');
+    const archived = dirs.filter((d) => d.location === 'archived');
+
+    expect(active.map((d) => d.number).sort()).toEqual(['07']);
+    expect(archived.map((d) => d.number).sort()).toEqual(['01', '02']);
+    for (const a of archived) {
+      expect(a.milestoneVersion).toBe('1.0');
+    }
+  });
+
+  test('returns empty list when neither tree exists', () => {
+    expect(listPhaseDirs(cwd)).toEqual([]);
+  });
+});
+
+describe('collectPhaseArtifacts', () => {
+  test('collects PLAN/SUMMARY/VERIFICATION/VALIDATION from an archived phase', () => {
+    const dir = join(
+      cwd,
+      '.planning',
+      'milestones',
+      'v1.0-phases',
+      '08-archive-target',
+    );
+    mkdirSync(dir, { recursive: true });
+    writeFrontmatter(join(dir, '08-PLAN.md'), '# plan\n');
+    writeFrontmatter(join(dir, '08-01-SUMMARY.md'), '# summary\n');
+    writeFrontmatter(
+      join(dir, '08-VERIFICATION.md'),
+      '---\nstatus: complete\n---\n',
+    );
+    writeFrontmatter(join(dir, '08-VALIDATION.md'), '# validation\n');
+
+    const artifacts = collectPhaseArtifacts(cwd, '08');
+    expect(artifacts.phaseDir).toBe(dir);
+    expect(artifacts.planFile).toContain('PLAN.md');
+    expect(artifacts.summaryFile).toContain('SUMMARY.md');
+    expect(artifacts.verificationFile).toContain('VERIFICATION.md');
+    expect(artifacts.validationFile).toContain('VALIDATION.md');
+    expect(artifacts.location).toBe('archived');
+    expect(artifacts.milestoneVersion).toBe('1.0');
+  });
+
+  test('returns null artifacts when phase cannot be resolved', () => {
+    const artifacts = collectPhaseArtifacts(cwd, '42');
+    expect(artifacts.phaseDir).toBeNull();
+    expect(artifacts.location).toBeNull();
+    expect(artifacts.milestoneVersion).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#25](https://github.com/weslien/stgsd/issues/25). After `complete-milestone` archives phase directories from `.planning/phases/` into `.planning/milestones/v<X.Y>-phases/`, `stclaude doctor` previously flagged every Complete STDB phase as `PHASE_DIR_MISSING` because the lookup never searched the archived tree. Result: archival forced a permanent non-zero finding count.

This PR teaches the disk-artifact layer about the archived layout and lets `doctor` report archived phases as informational rather than as divergences.

## Changes

- `src/cli/lib/disk-artifacts.ts`
  - New helper `listArchivedPhaseRoots(cwd)` that scans `.planning/milestones/` for `v*-phases/` roots.
  - New `resolvePhaseDir(cwd, phaseNumber)` that searches active first, then archived (newest milestone version first), and returns `{ path, location, milestoneVersion }`.
  - `findPhaseDir` is now a thin wrapper over `resolvePhaseDir` and falls back through both locations.
  - `listPhaseDirs` returns archived dirs too, each tagged with `location: 'active' | 'archived'` and `milestoneVersion`.
  - `PhaseArtifacts` carries `location` and `milestoneVersion` so callers can tell where the phase came from.
- `src/cli/commands/doctor.ts`
  - `PhaseFinding` gets a `severity: 'error' | 'info'` field. Only errors count toward `summary.findings`, drive `ok`, and set the non-zero exit code.
  - For each Complete STDB phase resolved from an archived tree, doctor now emits a single `info` finding describing the milestone version and archive path — no more `PHASE_DIR_MISSING`.
  - Summary reports `STDB phases`, `Disk phases` (active only), `Archived phases`, and `Findings` (errors only).
- `tests/disk-artifacts.test.ts` — `bun test` suite for active, archived, mixed (active wins), multi-milestone (newest wins), unpadded numbers, missing phase, and full `collectPhaseArtifacts` for an archived phase.
- `package.json` — adds `"test": "bun test"`.

## Test plan

- [x] `bun run build:cli` (esbuild bundle still builds)
- [x] `bun test` (11 / 11 pass)
- [x] Pre-existing `tsc` errors in `complete-phase.ts` and `get-codebase-map.ts` are unchanged on `main` and unrelated to this PR
- [ ] Manual: `mv .planning/phases/* .planning/milestones/v1.0-phases/` then `stclaude doctor` — expect `Findings: 0`, exit code `0`, archived phases listed under `Info:`
- [ ] Manual: `find-phase 01` (or any archived phase number) resolves to the archived path

## Notes for reviewer

- The active tree is preferred over archives, so existing behavior for live phases is unchanged.
- Severity field is additive; existing JSON consumers still see the same `findings[]` shape (with one extra string field).
- `summary.findings` now counts only errors (matching the exit-code semantics) and a new `archivedPhases` key is added — both intentional.