### PR TITLE
fix: doctor recognizes archived phase layout under milestones/

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -19,6 +19,7 @@ interface PhaseFinding {
   source: 'stdb' | 'disk';
   issue: string;
   remediation: string;
+  archivedMilestone?: string;
 }
 
 interface DoctorData {
@@ -46,7 +47,8 @@ function formatDoctor(data: unknown): string {
     return lines.join('\n');
   }
   for (const f of findings) {
-    lines.push(`[${f.source.toUpperCase()}] phase ${f.phase}${f.name ? ` (${f.name})` : ''}`);
+    const archived = f.archivedMilestone ? ` [archived under ${f.archivedMilestone}]` : '';
+    lines.push(`[${f.source.toUpperCase()}] phase ${f.phase}${f.name ? ` (${f.name})` : ''}${archived}`);
     lines.push(`  Issue:   ${f.issue}`);
     lines.push(`  Suggest: ${f.remediation}`);
     lines.push('');
@@ -93,12 +95,17 @@ export function registerDoctorCommand(program: Command): void {
           for (const p of stdbPhases) {
             if (p.status !== 'Complete') continue;
             const artifacts = collectPhaseArtifacts(cwd, p.number);
+            const archived = artifacts.archivedMilestone ?? undefined;
+            const archivedNote = archived
+              ? ` (archived under milestone ${archived})`
+              : '';
             if (!artifacts.phaseDir) {
               findings.push({
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
-                issue: 'Marked Complete in SpacetimeDB but phase directory missing on disk',
+                issue:
+                  'Marked Complete in SpacetimeDB but phase directory missing on disk (checked .planning/phases/ and .planning/milestones/<version>-phases/)',
                 remediation: `Run /gsd:verify-work to retroactively produce artifacts, or stclaude remove-phase ${p.number} to roll STDB back`,
               });
               continue;
@@ -108,8 +115,11 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
-                issue: `Complete in STDB but SUMMARY.md missing in ${artifacts.phaseDir}`,
-                remediation: 'Run /gsd:verify-work to generate SUMMARY.md retroactively',
+                archivedMilestone: archived,
+                issue: `Complete in STDB but SUMMARY.md missing in ${artifacts.phaseDir}${archivedNote}`,
+                remediation: archived
+                  ? `Restore SUMMARY.md in the milestone ${archived} archive, or roll STDB back with remove-phase`
+                  : 'Run /gsd:verify-work to generate SUMMARY.md retroactively',
               });
             }
             if (!artifacts.verificationFile) {
@@ -117,8 +127,11 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
-                issue: `Complete in STDB but VERIFICATION.md missing in ${artifacts.phaseDir}`,
-                remediation: 'Run /gsd:verify-work to generate VERIFICATION.md retroactively',
+                archivedMilestone: archived,
+                issue: `Complete in STDB but VERIFICATION.md missing in ${artifacts.phaseDir}${archivedNote}`,
+                remediation: archived
+                  ? `Restore VERIFICATION.md in the milestone ${archived} archive, or roll STDB back with remove-phase`
+                  : 'Run /gsd:verify-work to generate VERIFICATION.md retroactively',
               });
             } else {
               const fm = parseFrontmatter(artifacts.verificationFile);
@@ -127,7 +140,8 @@ export function registerDoctorCommand(program: Command): void {
                   phase: p.number,
                   name: p.name,
                   source: 'stdb',
-                  issue: `Complete in STDB but VERIFICATION.md status: gaps_found at ${artifacts.verificationFile}`,
+                  archivedMilestone: archived,
+                  issue: `Complete in STDB but VERIFICATION.md status: gaps_found at ${artifacts.verificationFile}${archivedNote}`,
                   remediation: 'Resolve gaps then re-run write-verification, or roll back with remove-phase',
                 });
               }
@@ -137,8 +151,11 @@ export function registerDoctorCommand(program: Command): void {
                 phase: p.number,
                 name: p.name,
                 source: 'stdb',
-                issue: `Complete in STDB but VALIDATION.md missing (nyquist_validation enabled) in ${artifacts.phaseDir}`,
-                remediation: 'Run /gsd:validate-phase to fill the Nyquist validation gap',
+                archivedMilestone: archived,
+                issue: `Complete in STDB but VALIDATION.md missing (nyquist_validation enabled) in ${artifacts.phaseDir}${archivedNote}`,
+                remediation: archived
+                  ? `Restore VALIDATION.md in the milestone ${archived} archive, or roll STDB back with remove-phase`
+                  : 'Run /gsd:validate-phase to fill the Nyquist validation gap',
               });
             }
           }
@@ -163,8 +180,11 @@ export function registerDoctorCommand(program: Command): void {
               findings.push({
                 phase: d.number,
                 source: 'disk',
+                archivedMilestone: d.archivedMilestone ?? undefined,
                 issue: `Phase directory ${d.path} has no matching phase row in SpacetimeDB`,
-                remediation: 'Run stclaude add-phase / insert-phase to register it, or delete the orphan directory',
+                remediation: d.archivedMilestone
+                  ? `Re-register with stclaude add-phase / insert-phase, or delete the orphan directory under .planning/milestones/${d.archivedMilestone}-phases/`
+                  : 'Run stclaude add-phase / insert-phase to register it, or delete the orphan directory',
               });
             }
           }

--- a/src/cli/lib/disk-artifacts.ts
+++ b/src/cli/lib/disk-artifacts.ts
@@ -7,6 +7,7 @@ export interface PhaseArtifacts {
   summaryFile: string | null;
   verificationFile: string | null;
   validationFile: string | null;
+  archivedMilestone: string | null;
 }
 
 export interface PhaseGateIssue {
@@ -63,59 +64,142 @@ export function comparePhaseNumber(a: string, b: string): number {
 }
 
 /**
- * Locate a phase directory under <cwd>/.planning/phases/ matching
- * the normalized phase number prefix (e.g. "04-" or exactly "04").
- * Returns null if .planning/phases is missing or no match.
+ * List milestone-archive phase roots under <cwd>/.planning/milestones/.
+ * Returned entries are subdirectories whose name ends in "-phases", e.g.
+ * "v1.0-phases" → { name: "v1.0-phases", version: "v1.0", path: ... }.
+ * Order is deterministic (descending by name) so newer milestones win
+ * when the same phase number is archived under multiple versions.
  */
-export function findPhaseDir(cwd: string, phaseNumber: string): string | null {
-  const phasesDir = join(cwd, '.planning', 'phases');
-  if (!existsSync(phasesDir)) return null;
-  const normalized = normalizePhaseNumber(phaseNumber);
+export function listMilestoneArchives(
+  cwd: string,
+): Array<{ name: string; version: string; path: string }> {
+  const root = join(cwd, '.planning', 'milestones');
+  if (!existsSync(root)) return [];
   let entries: string[];
   try {
-    entries = readdirSync(phasesDir);
+    entries = readdirSync(root);
+  } catch {
+    return [];
+  }
+  const out: Array<{ name: string; version: string; path: string }> = [];
+  for (const name of entries) {
+    if (!name.endsWith('-phases')) continue;
+    const full = join(root, name);
+    try {
+      if (!statSync(full).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    out.push({ name, version: name.slice(0, -'-phases'.length), path: full });
+  }
+  out.sort((a, b) => (a.version === b.version ? 0 : a.version < b.version ? 1 : -1));
+  return out;
+}
+
+function findPhaseDirIn(parentDir: string, normalized: string): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(parentDir);
   } catch {
     return null;
   }
-  // Prefer exact "<N>-..." match; fall back to bare "<N>" dir.
   const withSlug = entries.find((e) => e.startsWith(normalized + '-'));
   if (withSlug) {
-    const full = join(phasesDir, withSlug);
+    const full = join(parentDir, withSlug);
     if (statSync(full).isDirectory()) return full;
   }
   const exact = entries.find((e) => e === normalized);
   if (exact) {
-    const full = join(phasesDir, exact);
+    const full = join(parentDir, exact);
     if (statSync(full).isDirectory()) return full;
   }
   return null;
 }
 
 /**
- * List all phase directories under .planning/phases/ with parsed numbers.
+ * Locate a phase directory matching the normalized phase number prefix
+ * (e.g. "04-" or exactly "04"). Searches `.planning/phases/` first, then
+ * falls back to archived locations under `.planning/milestones/<version>-phases/`
+ * to support post-`complete-milestone` layouts.
+ *
+ * Returns the directory path and, if found in an archive, the milestone
+ * version it was archived under (e.g. "v1.0"). Returns null if no match.
+ */
+export function findPhaseDirWithArchive(
+  cwd: string,
+  phaseNumber: string,
+): { path: string; archivedMilestone: string | null } | null {
+  const normalized = normalizePhaseNumber(phaseNumber);
+
+  const phasesDir = join(cwd, '.planning', 'phases');
+  if (existsSync(phasesDir)) {
+    const direct = findPhaseDirIn(phasesDir, normalized);
+    if (direct) return { path: direct, archivedMilestone: null };
+  }
+
+  for (const archive of listMilestoneArchives(cwd)) {
+    const found = findPhaseDirIn(archive.path, normalized);
+    if (found) return { path: found, archivedMilestone: archive.version };
+  }
+
+  return null;
+}
+
+/**
+ * Locate a phase directory matching the normalized phase number prefix.
+ * Searches active phases under `.planning/phases/` first, then archived
+ * phases under `.planning/milestones/<version>-phases/`. Returns null if
+ * no match. See `findPhaseDirWithArchive` for archival metadata.
+ */
+export function findPhaseDir(cwd: string, phaseNumber: string): string | null {
+  return findPhaseDirWithArchive(cwd, phaseNumber)?.path ?? null;
+}
+
+/**
+ * List all phase directories under `.planning/phases/` and any archived
+ * milestone roots under `.planning/milestones/<version>-phases/`. Each entry
+ * is tagged with `archivedMilestone` (null for active phases, version string
+ * like "v1.0" for archived ones).
  */
 export function listPhaseDirs(
   cwd: string,
-): Array<{ name: string; path: string; number: string }> {
-  const phasesDir = join(cwd, '.planning', 'phases');
-  if (!existsSync(phasesDir)) return [];
-  let entries: string[];
-  try {
-    entries = readdirSync(phasesDir);
-  } catch {
-    return [];
-  }
-  const out: Array<{ name: string; path: string; number: string }> = [];
-  for (const name of entries) {
-    const full = join(phasesDir, name);
+): Array<{
+  name: string;
+  path: string;
+  number: string;
+  archivedMilestone: string | null;
+}> {
+  const out: Array<{
+    name: string;
+    path: string;
+    number: string;
+    archivedMilestone: string | null;
+  }> = [];
+
+  const collect = (parent: string, archivedMilestone: string | null) => {
+    if (!existsSync(parent)) return;
+    let entries: string[];
     try {
-      if (!statSync(full).isDirectory()) continue;
+      entries = readdirSync(parent);
     } catch {
-      continue;
+      return;
     }
-    const m = name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
-    if (!m) continue;
-    out.push({ name, path: full, number: m[1] });
+    for (const name of entries) {
+      const full = join(parent, name);
+      try {
+        if (!statSync(full).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      const m = name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
+      if (!m) continue;
+      out.push({ name, path: full, number: m[1], archivedMilestone });
+    }
+  };
+
+  collect(join(cwd, '.planning', 'phases'), null);
+  for (const archive of listMilestoneArchives(cwd)) {
+    collect(archive.path, archive.version);
   }
   return out;
 }
@@ -145,22 +229,24 @@ export function collectPhaseArtifacts(
   cwd: string,
   phaseNumber: string,
 ): PhaseArtifacts {
-  const phaseDir = findPhaseDir(cwd, phaseNumber);
-  if (!phaseDir) {
+  const located = findPhaseDirWithArchive(cwd, phaseNumber);
+  if (!located) {
     return {
       phaseDir: null,
       planFile: null,
       summaryFile: null,
       verificationFile: null,
       validationFile: null,
+      archivedMilestone: null,
     };
   }
   return {
-    phaseDir,
-    planFile: findArtifact(phaseDir, 'PLAN'),
-    summaryFile: findArtifact(phaseDir, 'SUMMARY'),
-    verificationFile: findArtifact(phaseDir, 'VERIFICATION'),
-    validationFile: findArtifact(phaseDir, 'VALIDATION'),
+    phaseDir: located.path,
+    planFile: findArtifact(located.path, 'PLAN'),
+    summaryFile: findArtifact(located.path, 'SUMMARY'),
+    verificationFile: findArtifact(located.path, 'VERIFICATION'),
+    validationFile: findArtifact(located.path, 'VALIDATION'),
+    archivedMilestone: located.archivedMilestone,
   };
 }
 
@@ -228,7 +314,7 @@ export function validatePhaseCompletion(
   if (!artifacts.phaseDir) {
     issues.push({
       code: 'PHASE_DIR_MISSING',
-      message: `Phase directory not found under .planning/phases/ for phase ${phaseNumber}`,
+      message: `Phase directory not found under .planning/phases/ or .planning/milestones/<version>-phases/ for phase ${phaseNumber}`,
     });
     return { issues, artifacts };
   }


### PR DESCRIPTION
## Summary
- Closes #25
- `findPhaseDir` / `collectPhaseArtifacts` / `listPhaseDirs` now fall back from `.planning/phases/` to `.planning/milestones/<version>-phases/`, so once `complete-milestone` archives a phase the doctor stops flagging `PHASE_DIR_MISSING`.
- `PhaseArtifacts` carries a new `archivedMilestone` field; `validatePhaseCompletion` keeps validating artifacts inside the archive (still surfaces missing `SUMMARY`/`VERIFICATION`/`VALIDATION`).
- `stclaude doctor` annotates findings with `[archived under v1.0]` and offers archive-aware remediation (restore in archive vs. roll STDB back).

## Test plan
- [x] Manual fixture (active phase + `v1.0-phases/` archive with one complete and one incomplete phase): archived complete phase ⇒ 0 findings, archived missing-artifact phase ⇒ targeted findings naming the archive path, missing-everywhere phase ⇒ updated `PHASE_DIR_MISSING` message that mentions both lookup roots.
- [x] `bun run build:cli` succeeds.
- [x] `tsc --noEmit` clean for the touched files (pre-existing errors elsewhere unchanged).